### PR TITLE
feat: 메인페이지 캘린더 하단 검색 결과 리스트 가출력

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BASE_URL = http://52.78.195.183:3003/api
+VITE_BASE_URL=http://52.78.195.183:3003/api

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -16,6 +16,7 @@ type CategoriesResponse = string[]
 
 // 검색어에 해당하는 소비 품목과 금액을 조회하는 서버 요청 데이터
 interface SearchResponseItem {
+    _id: string;
     amount: number;
     userId: string;
     category: string;

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,49 +1,49 @@
 // 소비 기록을 추가하거나 수정할 때 서버 요청 데이터
-interface ExpenseData  {
-    amount: number;
-    userId: string;
-    category: string;
-    date: string;
-  }
+interface ExpenseData {
+  amount: number;
+  userId: string;
+  category: string;
+  date: string;
+}
 
 // 소비 기록을 작성하는 요청이 성공하면 서버에서 반환하는 데이터
-interface ExpenseResponse  {
-    message: string;
+interface ExpenseResponse {
+  message: string;
 }
 
 // 소비 가능한 품목 목록을 요청하는 서버 데이터
-type CategoriesResponse = string[]
+type CategoriesResponse = string[];
 
 // 검색어에 해당하는 소비 품목과 금액을 조회하는 서버 요청 데이터
 interface SearchResponseItem {
-    _id: string;
-    amount: number;
-    userId: string;
-    category: string;
-    date: string;
-  }
-  
+  _id: string;
+  amount: number;
+  userId: string;
+  category: string;
+  date: string;
+}
+
 type SearchResponse = SearchResponseItem[];
 
 // 일별, 주별, 월별 소비 조회를 위한 서버 요청 데이터
 interface SummaryResponseItem {
-    _id: string;
-    totalAmount: number;
+  _id: string;
+  totalAmount: number;
 }
 
 type SummaryResponse = SearchResponseItem[];
 
 // 소비 기록을 수정하면 서버로부터 반환되는 응답 데이터
 type UpdateResponse = {
-    message: string;
-}
+  message: string;
+};
 
 // 소비 기록을 삭제하면 서버로부터 반환되는 응답 데이터
 type DeleteResponse = {
-    message: string;
-}
+  message: string;
+};
 
 // 소비 기록에 대한 서버로부터의 응답 데이터 타입 정의
 interface CalendarResponse {
-    [day: string]: ExpenseData;
-  }
+  [day: string]: ExpenseData;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Layout from '@/components/common/Layout';
 import Header from '@/components/common/Header';
 import NotFound from '@/components/common/NotFound';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import TheCalendar from '@/components/Home/TheCalender';
+import Home from '@/components/Home/Home';
 
 const App = () => {
   return (
@@ -12,7 +12,7 @@ const App = () => {
         <Header />
         <Routes>
           <Route path="/" element={<Layout />}>
-            <Route path="/" element={<TheCalendar />}></Route>
+            <Route path="/" element={<Home />}></Route>
             {/* 상단에 위치하는 라우트들의 규칙을 모두 확인, 일치하는 라우트가 없는경우 처리 */}
             <Route path="*" element={<NotFound />} />
             <Route path="/graph" element={<Graph />}></Route>

--- a/src/components/Home/ExpensesList.tsx
+++ b/src/components/Home/ExpensesList.tsx
@@ -1,0 +1,42 @@
+import { expenseSearch, expenseSummary } from '@/lib/api/Api';
+import { useCallback, useEffect, useState } from 'react';
+
+interface SummaryResponseItem {
+  _id: string;
+  totalAmount: number;
+}
+
+function ExpensesList() {
+  const [periodList, setPeriodList] = useState<SummaryResponseItem[]>([]);
+  const [cateoryList, setCateoryList] = useState<SearchResponseItem[]>([]);
+
+  const fetchList = useCallback(async () => {
+    const period = await expenseSummary('daily');
+    const category = await expenseSearch('식비');
+    setPeriodList(period);
+    setCateoryList(category);
+  }, []);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  return (
+    <div>
+      <div>일간, 주간, 월간 조회</div>
+      {periodList.map((item) => (
+        <li key={item._id}>
+          {item._id}: {item.totalAmount}
+        </li>
+      ))}
+      <div>카테고리 기반 검색</div>
+      {cateoryList.map((item) => (
+        <li key={item._id}>
+          {item.date}: {item.amount}
+        </li>
+      ))}
+    </div>
+  );
+}
+
+export default ExpensesList;

--- a/src/components/Home/ExpensesList.tsx
+++ b/src/components/Home/ExpensesList.tsx
@@ -1,5 +1,6 @@
-import { expenseSearch, expenseSummary } from '@/lib/api/Api';
+import ExpenseLayout from '@/ui/ExpenseLayout';
 import { useCallback, useEffect, useState } from 'react';
+import { expenseSearch, expenseSummary } from '@/lib/api/Api';
 
 interface SummaryResponseItem {
   _id: string;
@@ -11,8 +12,9 @@ function ExpensesList() {
   const [cateoryList, setCateoryList] = useState<SearchResponseItem[]>([]);
 
   const fetchList = useCallback(async () => {
-    const period = await expenseSummary('daily');
-    const category = await expenseSearch('식비');
+    const period = await expenseSummary('daily'); // 일별 소비 조회
+    const category = await expenseSearch('식비'); // 검색어(식비)에 해당하는 소비 일자와 금액을 조회
+
     setPeriodList(period);
     setCateoryList(category);
   }, []);
@@ -25,15 +27,15 @@ function ExpensesList() {
     <div>
       <div>일간, 주간, 월간 조회</div>
       {periodList.map((item) => (
-        <li key={item._id}>
-          {item._id}: {item.totalAmount}
-        </li>
+        <ExpenseLayout
+          key={item._id}
+          date={item._id}
+          totalAmount={item.totalAmount}
+        />
       ))}
       <div>카테고리 기반 검색</div>
       {cateoryList.map((item) => (
-        <li key={item._id}>
-          {item.date}: {item.amount}
-        </li>
+        <ExpenseLayout key={item._id} date={item.date} amount={item.amount} />
       ))}
     </div>
   );

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,9 +1,11 @@
 import TheCalendar from './TheCalender';
+import ExpensesList from './ExpensesList';
 
 function Home() {
   return (
     <div>
       <TheCalendar />
+      <ExpensesList />
     </div>
   );
 }

--- a/src/lib/api/Api.ts
+++ b/src/lib/api/Api.ts
@@ -1,145 +1,155 @@
-import { API_URL, HEADERS, userId } from "@/lib/api/Base";
+import { API_URL, HEADERS, userId } from '@/lib/api/Base';
 
 // 소비 기록 작성
 export const createdExpense = async (data: ExpenseData) => {
-    try {
-        const res = await fetch(`${API_URL}/expenses`, {
-            method: 'POST',
-            headers: HEADERS,
-            body: JSON.stringify(data),
-        });
-        // 소비 기록 작성 성공
-        if (res.ok) {
-            const data: ExpenseResponse = await res.json();
-            return data;
-        }
-        // 실패한 경우
-        throw new Error('기록 작성에 실패했습니다.');
-    } catch (error) {
-        console.error(error);
-        throw error;
+  try {
+    const res = await fetch(`${API_URL}/expenses`, {
+      method: 'POST',
+      headers: HEADERS,
+      body: JSON.stringify(data),
+    });
+    // 소비 기록 작성 성공
+    if (res.ok) {
+      const data: ExpenseResponse = await res.json();
+      return data;
     }
+    // 실패한 경우
+    throw new Error('기록 작성에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 // 소비 품목 목록
 export const expenseCategory = async () => {
-    try {
-        const res = await fetch(`${API_URL}/categories?userId=${userId}`, {
-            method: 'GET',
-            headers: HEADERS,
-        });
-        // 목록 호출 성공
-        if (res.ok) {
-            const data: CategoriesResponse = await res.json();
-            return data;
-        }
-        // 실패한 경우
-        throw new Error('카테고리를 불러오는데 실패했습니다.');
-    } catch (error) {
-        console.error(error);
-        throw error;
+  try {
+    const res = await fetch(`${API_URL}/categories?userId=${userId}`, {
+      method: 'GET',
+      headers: HEADERS,
+    });
+    // 목록 호출 성공
+    if (res.ok) {
+      const data: CategoriesResponse = await res.json();
+      return data;
     }
+    // 실패한 경우
+    throw new Error('카테고리를 불러오는데 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 // 검색어에 해당하는 소비 항목 및 금액 조회
 export const expenseSearch = async (keyword: string) => {
-    try {
-        const encodedKeyword = encodeURIComponent(keyword);
-        const res = await fetch(`${API_URL}/expenses/search?q=${encodedKeyword}&userId=${userId}`, {
-          method: 'GET',
-          headers: HEADERS,
-        });
-      
-      // 성공
-      if (res.ok) {
-        const data: SearchResponse = await res.json();
-        return data;
-      }
-      // 실패
-      throw new Error('검색에 실패했습니다.');
-    } catch (error) {
-      console.error(error);
-      throw error;
+  try {
+    const encodedKeyword = encodeURIComponent(keyword);
+    const res = await fetch(
+      `${API_URL}/expenses/search?q=${encodedKeyword}&userId=${userId}`,
+      {
+        method: 'GET',
+        headers: HEADERS,
+      },
+    );
+
+    // 성공
+    if (res.ok) {
+      const data: SearchResponse = await res.json();
+      return data;
     }
-  };
+    // 실패
+    throw new Error('검색에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
 
 // 일별, 주별, 월별 소비 조회
-  export const expenseSummary = async (period: string) => {
-    try {
-      const res = await fetch(`${API_URL}/expenses/summary?period=${period}&userId=${userId}`, {
+export const expenseSummary = async (period: string) => {
+  try {
+    const res = await fetch(
+      `${API_URL}/expenses/summary?period=${period}&userId=${userId}`,
+      {
         method: 'GET',
-        headers: HEADERS
-      });
-  
-      if (res.ok) {
-        const data: SummaryResponseItem[] = await res.json();
-        return data;
-      }
-  
-      throw new Error('조회에 실패했습니다.');
-    } catch (error) {
-      console.error(error);
-      throw error;
+        headers: HEADERS,
+      },
+    );
+    console.log(API_URL);
+    if (res.ok) {
+      const data: SummaryResponseItem[] = await res.json();
+      console.log(data);
+      return data;
     }
-  };
 
-  // 소비 기록 수정
-  export const updatedRecord = async(id:string, data: ExpenseData) => {
-    try {
-        const res = await fetch(`${API_URL}/expenses/${id}`, {
-            method: 'PUT',
-            headers: HEADERS,
-            body: JSON.stringify(data),
-        });
+    throw new Error('조회에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
 
-        if (res.ok) {
-            const data: UpdateResponse = await res.json();
-            return data;
-        }
+// 소비 기록 수정
+export const updatedRecord = async (id: string, data: ExpenseData) => {
+  try {
+    const res = await fetch(`${API_URL}/expenses/${id}`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify(data),
+    });
 
-        throw new Error('수정에 실패했습니다.')
-    } catch (error) {
-        console.error(error);
-        throw error;
+    if (res.ok) {
+      const data: UpdateResponse = await res.json();
+      return data;
     }
-  };
 
-  // 소비 기록 삭제
-  export const deletedRecord = async(id:string) => {
-    try {
-        const res = await fetch(`${API_URL}/expenses/${id}`, {
-            method: 'DELETE',
-            headers: HEADERS
-        });
+    throw new Error('수정에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
 
-        if (res.ok) {
-            const data: DeleteResponse = await res.json();
-            return data;
-        }
+// 소비 기록 삭제
+export const deletedRecord = async (id: string) => {
+  try {
+    const res = await fetch(`${API_URL}/expenses/${id}`, {
+      method: 'DELETE',
+      headers: HEADERS,
+    });
 
-        throw new Error('삭제에 실패했습니다.')
-    } catch (error) {
-        console.error(error);
-        throw error;
+    if (res.ok) {
+      const data: DeleteResponse = await res.json();
+      return data;
     }
-  };
 
-  // 소비 기록 달력 호출
-  export const calendarData = async(year: number, month: number) => {
-    try {
-        const res = await fetch(`${API_URL}/calendar?year=${year}&month=${month}&userId=${userId}`, {
-            method: 'GET',
-            headers: HEADERS
-        });
+    throw new Error('삭제에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
 
-        if (res.ok) {
-            const data: CalendarResponse = await res.json();
-            return data
-        }
+// 소비 기록 달력 호출
+export const calendarData = async (year: number, month: number) => {
+  try {
+    const res = await fetch(
+      `${API_URL}/calendar?year=${year}&month=${month}&userId=${userId}`,
+      {
+        method: 'GET',
+        headers: HEADERS,
+      },
+    );
 
-        throw new Error('호출에 실패했습니다.')
-    } catch (error) {
-        console.error(error);
-        throw error;
+    if (res.ok) {
+      const data: CalendarResponse = await res.json();
+      return data;
     }
-  };
+
+    throw new Error('호출에 실패했습니다.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/ui/ExpenseLayout.tsx
+++ b/src/ui/ExpenseLayout.tsx
@@ -1,0 +1,23 @@
+import { theme } from '@/styles/theme';
+import { styled } from 'styled-components';
+
+interface ExpenseProps {
+  key?: string;
+  date?: string;
+  totalAmount?: number;
+  amount?: number;
+}
+
+function ExpenseLayout({ ...props }: ExpenseProps) {
+  return (
+    <Wrapper>
+      {props.date}: {props.totalAmount ? props.totalAmount : props.amount}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  background-color: ${theme.colors.green};
+  border-top: 1px solid #000;
+`;
+export default ExpenseLayout;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,16 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import * as path from "path";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import * as path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
+  },
+  server: {
+    port: 3000,
   },
 });


### PR DESCRIPTION
- 일별 소비 조회 임시 구현(API 테스트)
- 검색어(식비)에 해당하는 일자와 금액 출력(테스트)